### PR TITLE
release: enable debug logging during build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,10 @@ jobs:
 
       - name: Build distribution
         run: |
+          set -x
+          export BUILDSYS_DATEVERSION_DEBUG=/tmp/buildsys-dateversion.log
           python -mbuild
+          cat /tmp/buildsys-dateversion.log
 
       - name: Prepare for wheel check
         run: |


### PR DESCRIPTION
Something is going wrong with the version assignment, enable the logs to get some clues.