### PR TITLE
Force version path rather than relying on autodetect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = { file = "requirements.in" }
 [tool.isort]
 profile = "black"
 
+[tool.buildsys-dateversion]
+version-path = "src/buildsys_dateversion/__init__.py"
+
 [build-system]
 requires = []
 backend-path = ["src"]

--- a/src/buildsys_dateversion/_hooks.py
+++ b/src/buildsys_dateversion/_hooks.py
@@ -76,6 +76,10 @@ class DateVersion:
                 if not file.endswith(".py"):
                     continue
 
+                # TODO: revisit handling of multiple matches:
+                # - assume shortest path is the best?
+                # - give fatal error?
+                # - update all of them?
                 path = os.path.join(dirpath, file)
                 LOG.debug("Checking file %s", path)
                 if VERSION_PATTERN.search(open(path).read()):


### PR DESCRIPTION
This repo has several files containing `__version__`, seeing as there's a few sample projects under `tests/` directory. Better explicitly set the path to the file we want to manage.